### PR TITLE
Feature #12 - Duplicate ticket in sprints and some improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 BigRoomPlanningBoardBackend/bin/*
 BigRoomPlanningBoardBackend/obj/*
+BigRoomPlanningBoardBackend/brp.db

--- a/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/data.service.ts
+++ b/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/data.service.ts
@@ -67,8 +67,6 @@ export class DataService {
     private connectionService: ConnectionService,
     private processEventService: ProcessEventService
   ) {
-    this.queue.length()
-    
     this.connectionService.onRecieveFullData((events: IBRPFullData) => {
       this.recieveFullData(events);
     });

--- a/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/sprint-column/edit-squad-sprint-stats-dialog/edit-squad-sprint-stats-dialog.component.html
+++ b/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/sprint-column/edit-squad-sprint-stats-dialog/edit-squad-sprint-stats-dialog.component.html
@@ -7,18 +7,18 @@
                 <input matSliderThumb [formControlName]="'capacity'">
             </mat-slider>
             <mat-form-field style="width: 6rem;" appearance="outline">
-                <mat-label>%</mat-label>
+                <span matTextSuffix>%</span>
                 <input matInput [formControlName]="'capacity'" type="number">
               </mat-form-field>
         </div>
         <div i18n>Background Noise</div>
         <div class="d-flex flex-row">
             <mat-slider style="flex-grow: 1;" [step]="0.5" [min]="0" [max]="100" discrete [displayWith]="formatLabel">
-                <input matSliderThumb  formControlName="backgroundNoise">
+                <input matSliderThumb formControlName="backgroundNoise">
             </mat-slider>
             <mat-form-field style="width: 6rem;" appearance="outline">
-                <mat-label>%</mat-label>
-                <input matInput  formControlName="backgroundNoise" type="number">
+                <span matTextSuffix>%</span>
+                <input matInput formControlName="backgroundNoise" type="number">
               </mat-form-field>
             </div>
         <mat-form-field>

--- a/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/sprint-column/edit-squad-sprint-stats-dialog/edit-squad-sprint-stats-dialog.component.html
+++ b/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/sprint-column/edit-squad-sprint-stats-dialog/edit-squad-sprint-stats-dialog.component.html
@@ -2,13 +2,25 @@
 <mat-dialog-content>
     <form class="d-flex flex-column form-column" style="margin-top: 1rem;" [formGroup]="formGroup" (ngSubmit)="saveClick()">
         <div i18n>Capacity</div>
-        <mat-slider [step]="0.5" [min]="0" [max]="100" discrete [displayWith]="formatLabel">
-            <input matSliderThumb [formControlName]="'capacity'">
-        </mat-slider>
+        <div class="d-flex flex-row">
+            <mat-slider style="flex-grow: 1;" [step]="0.5" [min]="0" [max]="100" discrete [displayWith]="formatLabel">
+                <input matSliderThumb [formControlName]="'capacity'">
+            </mat-slider>
+            <mat-form-field style="width: 6rem;" appearance="outline">
+                <mat-label>%</mat-label>
+                <input matInput [formControlName]="'capacity'" type="number">
+              </mat-form-field>
+        </div>
         <div i18n>Background Noise</div>
-        <mat-slider [step]="0.5" [min]="0" [max]="100" discrete [displayWith]="formatLabel">
-            <input matSliderThumb [formControlName]="'backgroundNoise'">
-        </mat-slider>
+        <div class="d-flex flex-row">
+            <mat-slider style="flex-grow: 1;" [step]="0.5" [min]="0" [max]="100" discrete [displayWith]="formatLabel">
+                <input matSliderThumb  formControlName="backgroundNoise">
+            </mat-slider>
+            <mat-form-field style="width: 6rem;" appearance="outline">
+                <mat-label>%</mat-label>
+                <input matInput  formControlName="backgroundNoise" type="number">
+              </mat-form-field>
+            </div>
         <mat-form-field>
             <mat-label>Note</mat-label>
             <textarea matInput formControlName="note"></textarea>

--- a/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/sprint-column/edit-squad-sprint-stats-dialog/edit-squad-sprint-stats-dialog.component.ts
+++ b/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/sprint-column/edit-squad-sprint-stats-dialog/edit-squad-sprint-stats-dialog.component.ts
@@ -36,7 +36,7 @@ import { MatInputModule } from '@angular/material/input';
     ReactiveFormsModule,
     MatButton,
     MatFormFieldModule,
-    MatInputModule
+    MatInputModule,
   ],
   templateUrl: './edit-squad-sprint-stats-dialog.component.html',
   styleUrl: './edit-squad-sprint-stats-dialog.component.scss'
@@ -54,7 +54,12 @@ export class EditSquadSprintStatsDialogComponent implements OnInit {
     private matDialogRef: MatDialogRef<EditSquadSprintStatsDialogComponent>,
     private createEventService: CreateEventService
   ) {
-
+    this.formGroup.controls.backgroundNoise.valueChanges.subscribe(value => {
+      this.formGroup.controls.backgroundNoise.setValue(value, { emitEvent: false });
+    });
+    this.formGroup.controls.capacity.valueChanges.subscribe(value => {
+      this.formGroup.controls.capacity.setValue(value, { emitEvent: false });
+    });
   }
 
   ngOnInit(): void {

--- a/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/duplicate-ticket-dialog/duplicate-ticket-dialog.component.html
+++ b/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/duplicate-ticket-dialog/duplicate-ticket-dialog.component.html
@@ -1,0 +1,23 @@
+<h2 mat-dialog-title i18n>Duplicate Ticket: {{data.title}}</h2>
+<mat-dialog-content>
+  <form [formGroup]="formGroup">
+    <mat-form-field>
+      <mat-label>Title</mat-label>
+      <input matInput formControlName="ticketName"/>
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Sprint</mat-label>
+      <mat-select formControlName="sprintId">
+        @for (sprint of sprintFilter$ | async; track $index) {
+          <mat-option [value]="sprint.sprintId">{{ sprint.name }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </form>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-button (click)="cancel()" i18n>Cancel</button>
+  <button mat-flat-button (click)="createDuplicateTicket()" i18n>
+    Create
+  </button>
+</mat-dialog-actions>

--- a/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/duplicate-ticket-dialog/duplicate-ticket-dialog.component.html
+++ b/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/duplicate-ticket-dialog/duplicate-ticket-dialog.component.html
@@ -1,14 +1,14 @@
 <h2 mat-dialog-title i18n>Duplicate Ticket: {{data.title}}</h2>
 <mat-dialog-content>
-  <form [formGroup]="formGroup">
+  <form [formGroup]="formGroup" style="display: flex; flex-direction: column; gap: 0.5rem;">
     <mat-form-field>
       <mat-label>Title</mat-label>
       <input matInput formControlName="ticketName"/>
     </mat-form-field>
     <mat-form-field>
       <mat-label>Sprint</mat-label>
-      <mat-select formControlName="sprintId">
-        @for (sprint of sprintFilter$ | async; track $index) {
+      <mat-select multiple formControlName="sprintIds">
+        @for (sprint of sprintFilterValues$ | async; track $index) {
           <mat-option [value]="sprint.sprintId">{{ sprint.name }}</mat-option>
         }
       </mat-select>

--- a/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/duplicate-ticket-dialog/duplicate-ticket-dialog.component.ts
+++ b/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/duplicate-ticket-dialog/duplicate-ticket-dialog.component.ts
@@ -1,0 +1,107 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIcon } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { select, Store } from '@ngrx/store';
+import { Sprint, Ticket } from '../../../client';
+import { CreateEventService } from '../../../create-event.service';
+import { map, Observable, switchMap } from 'rxjs';
+import { getPlannedPeriods, getSprints } from '../../../store/app.selectors';
+import create from '@kahmannf/iterable-transforms';
+import { AsyncPipe } from '@angular/common';
+
+@Component({
+  selector: 'app-duplicate-ticket-dialog',
+  standalone: true,
+  imports: [
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatInputModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatTooltipModule,
+    AsyncPipe
+  ],
+  templateUrl: './duplicate-ticket-dialog.component.html',
+  styleUrl: './duplicate-ticket-dialog.component.scss',
+})
+export class DuplicateTicketDialogComponent implements OnInit {
+
+  /**
+   * Form group for the dialog.
+   */
+  formGroup = new FormGroup({
+    ticketName: new FormControl('', Validators.required),
+    sprintId: new FormControl<number>(-1, Validators.required),
+  });
+
+  sprintFilter$: Observable<Sprint[]>;
+
+  constructor(
+    private store$: Store<any>,
+    private matDialogRef: MatDialogRef<DuplicateTicketDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: Ticket,
+    private createEventService: CreateEventService
+  ) {}
+
+  /**
+   * The sprint filter observable.
+   */
+  ngOnInit(): void {
+    const plannedPeriod$ = this.store$.pipe(
+      select(getPlannedPeriods),
+      map(periods => periods.find(x => x.plannedPeriodId === this.data.plannedPeriodId))
+    )
+
+    this.sprintFilter$ = this.store$.pipe(
+      select(getSprints),
+      switchMap(sprints => plannedPeriod$.pipe(
+        map(plannedPeriod => ({ sprints, plannedPeriod }))
+      )),
+      map(({ sprints, plannedPeriod }) => create(sprints)
+        .filter(x => x.endsAt.getTime() >= plannedPeriod.startDay.getTime() && x.endsAt.getTime() <= plannedPeriod.endDay.getTime())
+        .sort(x => x.name)
+        .toArray()
+      ),
+      map(sprints => ([
+        new Sprint({
+          name: $localize`Backlog`,
+          sprintId: -1
+        }),
+        ...sprints
+      ]))
+    )
+  }
+
+  createDuplicateTicket() {
+    throw new Error('Method not implemented.');
+
+    this.createEventService.addTicket({
+      title: this.formGroup.controls.ticketName.value,
+      sprintId: this.formGroup.controls.sprintId.value,
+      ...this.data
+    });
+  }
+
+  /**
+   * Close the dialog.
+   */
+  cancel(): void {
+    this.matDialogRef.close();
+  }
+}

--- a/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/ticket-card.component.html
+++ b/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/ticket-card.component.html
@@ -40,6 +40,7 @@
 <ng-template #contextMenu>
     <div class="example-menu" cdkMenu>
         <button class="example-menu-item" cdkMenuItem (click)="edit()" i18n>Edit</button>
+        <button class="example-menu-item" cdkMenuItem (click)="addTicketAnotherSprint()" i18n>Duplicate in another sprint</button>
         <button class="example-menu-item" cdkMenuItem (click)="addDependency()" i18n>Edit Dependencies</button>
         <button class="example-menu-item" cdkMenuItem (click)="createDependencyTicket()" i18n>Create Dependency Ticket</button>
         <button class="example-menu-item" cdkMenuItem (click)="delete()" i18n>Delete</button>

--- a/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/ticket-card.component.html
+++ b/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/ticket-card.component.html
@@ -40,9 +40,31 @@
 <ng-template #contextMenu>
     <div class="example-menu" cdkMenu>
         <button class="example-menu-item" cdkMenuItem (click)="edit()" i18n>Edit</button>
-        <button class="example-menu-item" cdkMenuItem (click)="addTicketAnotherSprint()" i18n>Duplicate in another sprint</button>
-        <button class="example-menu-item" cdkMenuItem (click)="addDependency()" i18n>Edit Dependencies</button>
-        <button class="example-menu-item" cdkMenuItem (click)="createDependencyTicket()" i18n>Create Dependency Ticket</button>
-        <button class="example-menu-item" cdkMenuItem (click)="delete()" i18n>Delete</button>
+        <mat-divider></mat-divider>
+        <button class="example-menu-item" cdkMenuItem [cdkMenuTriggerFor]="DependencyContextMenu" i18n>
+            Dependency
+        </button>
+        <mat-divider></mat-divider>
+        <button class="example-menu-item" cdkMenuItem (click)="addTicketAnotherSprint()" i18n>Duplicate</button>
+        <button class="example-menu-item" cdkMenuItem (click)="deleteTicket(confirm_deleteTicket_dialog)" i18n>Delete</button>
     </div>
+</ng-template>
+
+<ng-template #DependencyContextMenu>
+    <div class="example-menu" cdkMenu>
+        <button class="example-menu-item" cdkMenuItem (click)="addDependency()" i18n>Edit</button>
+        <button class="example-menu-item" cdkMenuItem (click)="createDependencyTicket()" i18n>Create Ticket</button>
+    </div>
+</ng-template>
+
+
+<ng-template #confirm_deleteTicket_dialog>
+    <h2 mat-dialog-title i18n>Delete Ticket: {{ticket?.title}}</h2>
+    <mat-dialog-content>
+        <p i18n>Are you sure you want to delete this ticket?</p>
+    </mat-dialog-content>
+    <mat-dialog-actions>
+        <button mat-button mat-dialog-close i18n>Cancel</button>
+        <button mat-flat-button [mat-dialog-close]="true" i18n>Delete</button>
+    </mat-dialog-actions>
 </ng-template>

--- a/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/ticket-card.component.scss
+++ b/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/ticket-card.component.scss
@@ -47,10 +47,14 @@ mat-card-header {
 .example-menu {
   display: inline-flex;
   flex-direction: column;
+  padding: 0.5rem;
+  gap: 0.25rem;
   min-width: 180px;
   max-width: 280px;
-  background-color: var(--sys-surface-container);
-  padding: 6px 0;
+  background-color: var(--sys-surface-container-high);
+  border-color: var(--sys-surface-container-high);
+  border-radius: var(--mdc-elevated-card-container-shape, var(--mat-sys-corner-medium));
+  box-shadow: var(--mdc-elevated-card-container-elevation, var(--mat-sys-level1));
 }
 
 .example-menu-item {
@@ -71,7 +75,7 @@ mat-card-header {
 }
 
 .example-menu-item:hover {
-  background-color: var(--sys-surface-container-high);
+  background-color: var(--sys-surface-container-highest);
 }
 
 .example-menu-item:active {

--- a/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/ticket-card.component.ts
+++ b/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/ticket-card.component.ts
@@ -2,6 +2,7 @@ import {
   CdkContextMenuTrigger,
   CdkMenu,
   CdkMenuItem,
+  CdkMenuTrigger,
 } from '@angular/cdk/menu';
 import { AsyncPipe } from '@angular/common';
 import {
@@ -15,7 +16,7 @@ import {
   MatCardContent,
   MatCardHeader,
 } from '@angular/material/card';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
 
 import {
@@ -55,6 +56,8 @@ import { CreateDependencyTicketComponent } from './create-dependency-ticket/crea
 import { MatChipsModule } from '@angular/material/chips';
 import { MatBadgeModule } from '@angular/material/badge';
 import { DuplicateTicketDialogComponent } from './duplicate-ticket-dialog/duplicate-ticket-dialog.component';
+import { MatDivider } from '@angular/material/divider';
+import { MatButtonModule } from '@angular/material/button';
 
 interface DependencyWithInfo extends IDependency {
   fullfilled: boolean;
@@ -69,12 +72,16 @@ interface DependencyWithInfo extends IDependency {
     MatCardContent,
     AsyncPipe,
     CdkMenu,
+    MatDivider,
     CdkMenuItem,
+    CdkMenuTrigger,
     CdkContextMenuTrigger,
     MatIcon,
+    MatDialogModule,
     SquadNamePipe,
     MatChipsModule,
-    MatBadgeModule
+    MatBadgeModule,
+    MatButtonModule
   ],
   templateUrl: './ticket-card.component.html',
   styleUrl: './ticket-card.component.scss'
@@ -295,7 +302,7 @@ export class TicketCardComponent implements OnChanges {
   addTicketAnotherSprint(): void {
     this.matDialog.open(DuplicateTicketDialogComponent, {
       data: this.ticket,
-      disableClose: true
+      disableClose: false
     })
   }
 
@@ -306,7 +313,7 @@ export class TicketCardComponent implements OnChanges {
       width: '60rem',
       maxWidth: '60vw',
       data: this.ticket,
-      disableClose: true
+      disableClose: false
     });
   }
 
@@ -316,12 +323,16 @@ export class TicketCardComponent implements OnChanges {
       width: '40rem',
       maxWidth: '60vw',
       data: this.ticket,
-      disableClose: true
+      disableClose: false
     })
   }
 
-  delete() {
-    this.createEventServie.deleteTicket(this.ticket.ticketId);
+  deleteTicket(template): void {
+    this.matDialog.open(template, {disableClose: false}).afterClosed().subscribe(result => {
+      if(result) {
+        this.createEventServie.deleteTicket(this.ticket.ticketId);
+      }
+    });
   }
 
   mouseEnter() {

--- a/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/ticket-card.component.ts
+++ b/BigRoomPlanningBoardBackend/ng-big-room-planning/src/app/planned-period-base/ticket-card/ticket-card.component.ts
@@ -54,6 +54,7 @@ import {
 import { CreateDependencyTicketComponent } from './create-dependency-ticket/create-dependency-ticket.component';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatBadgeModule } from '@angular/material/badge';
+import { DuplicateTicketDialogComponent } from './duplicate-ticket-dialog/duplicate-ticket-dialog.component';
 
 interface DependencyWithInfo extends IDependency {
   fullfilled: boolean;
@@ -286,6 +287,13 @@ export class TicketCardComponent implements OnChanges {
 
   edit() {
     this.matDialog.open(EditTicketDialogComponent, {
+      data: this.ticket,
+      disableClose: true
+    })
+  }
+
+  addTicketAnotherSprint(): void {
+    this.matDialog.open(DuplicateTicketDialogComponent, {
       data: this.ticket,
       disableClose: true
     })


### PR DESCRIPTION
This pull request includes multiple changes to improve the user interface and functionality of the BigRoomPlanningBoard application. The most important changes include the addition of a duplicate ticket dialog, enhancements to the edit squad sprint stats dialog, and updates to the context menu for ticket cards.

### Enhancements to dialogs and forms:
* Added a new duplicate ticket dialog with form fields for title and sprint selection, including the necessary imports and component setup (`duplicate-ticket-dialog.component.html`, `duplicate-ticket-dialog.component.ts`) [[1]](diffhunk://#diff-9fb55d374bba75ec3c26974be3ce70d5c3aca532ba58965a677b893c34a5413bR1-R23) [[2]](diffhunk://#diff-4cf7fc37e683cab9d75c1c0fdf3cba0800d1640410a1ceef8fb06578538e87beR1-R127).
* Improved the edit squad sprint stats dialog by adding number input fields alongside sliders for capacity and background noise (`edit-squad-sprint-stats-dialog.component.html`, `edit-squad-sprint-stats-dialog.component.ts`) [[1]](diffhunk://#diff-0bd986c2bb903d74710462a5288b0b83176a57093de46df79cbc79c8d767029eL5-R23) [[2]](diffhunk://#diff-c804fca09e15197b38b7d15f92d6ce70ae460abc9c631bd778a8ae12521a1362L57-R62).

### Updates to ticket card context menu:
* Modified the ticket card context menu to include options for duplicating tickets and confirming ticket deletion, along with the necessary template and style adjustments (`ticket-card.component.html`, `ticket-card.component.scss`) [[1]](diffhunk://#diff-a09bf4706f780a2af8fda97e9654fe065ce98bef0374c93dd6d0edcbc8c5410aL43-R70) [[2]](diffhunk://#diff-c79401310d276274fc3c3bcb51b7d45a48e4318f02ce49cf3b4a72abe6bbde0aR50-R57) [[3]](diffhunk://#diff-c79401310d276274fc3c3bcb51b7d45a48e4318f02ce49cf3b4a72abe6bbde0aL74-R78).
* Added functionality to open the duplicate ticket dialog and handle ticket deletion confirmation (`ticket-card.component.ts`) [[1]](diffhunk://#diff-a18557b7e8ba505a79c09cda23629f7a38e378e375834d80b03637d36909949eR302-R316) [[2]](diffhunk://#diff-a18557b7e8ba505a79c09cda23629f7a38e378e375834d80b03637d36909949eL311-R336).

### Code cleanup and minor improvements:
* Removed unused code in `data.service.ts` to improve code readability and maintainability (`data.service.ts`).
* Updated module imports and declarations to support the new and modified components (`edit-squad-sprint-stats-dialog.component.ts`, `ticket-card.component.ts`) [[1]](diffhunk://#diff-c804fca09e15197b38b7d15f92d6ce70ae460abc9c631bd778a8ae12521a1362L39-R39) [[2]](diffhunk://#diff-a18557b7e8ba505a79c09cda23629f7a38e378e375834d80b03637d36909949eR5) [[3]](diffhunk://#diff-a18557b7e8ba505a79c09cda23629f7a38e378e375834d80b03637d36909949eL18-R19) [[4]](diffhunk://#diff-a18557b7e8ba505a79c09cda23629f7a38e378e375834d80b03637d36909949eR58-R60) [[5]](diffhunk://#diff-a18557b7e8ba505a79c09cda23629f7a38e378e375834d80b03637d36909949eR75-R84).

![image](https://github.com/user-attachments/assets/6066cdfd-152f-4e74-ab3e-13a98c891548)
